### PR TITLE
Support for private repos

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -58,7 +58,7 @@ try {
         const args = ['clone', '--depth=1'];
         if (ref)
             args.push('--branch', ref);
-        args.push(`https://github.com/${owner}/${repo}`);
+        args.push(`https://${token}@github.com/${owner}/${repo}.git`);
         await execOrThrow('git', args);
         if (subrepoSubdirectory) {
             const tempDirName = 'temporary-docs-dir';

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ try {
 
     const args = ['clone', '--depth=1'];
     if (ref) args.push('--branch', ref);
-    args.push(`https://{$token}@github.com/${owner}/${repo}.git`);
+    args.push(`https://${token}@github.com/${owner}/${repo}.git`);
 
     await execOrThrow('git', args);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ try {
 
     const args = ['clone', '--depth=1'];
     if (ref) args.push('--branch', ref);
-    args.push(`https://github.com/${owner}/${repo}`);
+    args.push(`https://{$token}@github.com/${owner}/${repo}.git`);
 
     await execOrThrow('git', args);
 


### PR DESCRIPTION
Hey there - I wonder if you'd be open to a PR for this

The github action didn't work out of the box, for our private repos, even though the PAT had the correct permissions. I suspected that even though you're setting the token in the header, it wasn't actually getting recognized correctly

This PR just changes the `git clone` command to use the format PAT@https://REPO/URL.git and updates the /dist folder accordingly. Tested this and confirmed it works on both public and private repos with this fix